### PR TITLE
Bump prompt-lists to ^0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "flowbite": "^4.0.2",
         "lodash.debounce": "^4.0.8",
         "next": "^16.2.9",
-        "prompt-lists": "^0.3.2",
+        "prompt-lists": "^0.4.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -5655,9 +5655,9 @@
       }
     },
     "node_modules/prompt-lists": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/prompt-lists/-/prompt-lists-0.3.2.tgz",
-      "integrity": "sha512-PAx/AHIUjo1bqV0iMmV3mn3X1H+Kbb880V6B7Nx0IFUV0qyQsRBVoDxgu1f5VA3qQlHxMerWwGX1gq5q9jJUAg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/prompt-lists/-/prompt-lists-0.4.0.tgz",
+      "integrity": "sha512-LflS5ahPf5UZisnbAY2gkdkuUnDw4js3Ga4VdMcQD5zN6Gax20Z4M7317Wmr7GUT71E/mNJTwNQIFjbVMEpuNQ==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "flowbite": "^4.0.2",
     "lodash.debounce": "^4.0.8",
     "next": "^16.2.9",
-    "prompt-lists": "^0.3.2",
+    "prompt-lists": "^0.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },


### PR DESCRIPTION
Updates the `prompt-lists` dependency from `^0.3.2` to `^0.4.0`.

**What's in 0.4.0** (just published to npm):
- 100+ new lists with exhaustive coverage
- New/expanded categories: vehicles (aircraft, motorcycle, watercraft, spacecraft), typography, video-game, animated TV shows, onomatopoeia, and more
- A dedupe pass — now **350 lists** total

Only `package.json` + `package-lock.json` change; lockfile integrity matches the published `prompt-lists@0.4.0` tarball.

- npm: https://www.npmjs.com/package/prompt-lists/v/0.4.0
- Release: https://github.com/ai-prompts/prompt-lists/releases/tag/v0.4.0