### PR TITLE
POC: JSON prompt template builder

### DIFF
--- a/components/JsonTemplateBuilder.js
+++ b/components/JsonTemplateBuilder.js
@@ -91,6 +91,14 @@ const JsonTemplateBuilder = () => {
     setTimeout(() => setCopied(""), 1200);
   };
 
+  // Copy every variation minified onto its own line (NDJSON), so it drops
+  // straight into batch tools that take one prompt per line.
+  const copyAllLines = () => {
+    navigator.clipboard.writeText(variations.map((v) => JSON.stringify(v)).join("\n"));
+    setCopied("all");
+    setTimeout(() => setCopied(""), 1200);
+  };
+
   return (
     <div>
       <div className="bg-gray-50 border-2 border-gray-200 p-4 mb-6 text-sm">
@@ -212,9 +220,9 @@ const JsonTemplateBuilder = () => {
             <button
               type="button"
               className="button"
-              onClick={() => copy(variations, "all")}
+              onClick={copyAllLines}
             >
-              {copied === "all" ? "Copied!" : "Copy all (array)"}
+              {copied === "all" ? "Copied!" : "Copy all (one per line)"}
             </button>
           </div>
           <div className="grid gap-3 md:grid-cols-2">

--- a/components/JsonTemplateBuilder.js
+++ b/components/JsonTemplateBuilder.js
@@ -1,0 +1,242 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import ReactTextareaAutocomplete from "@webscopeio/react-textarea-autocomplete";
+import debounce from "lodash.debounce";
+import autocompleteLists from "prompt-lists/lists.json";
+import Link from "next/link";
+
+const tokenList = [...autocompleteLists];
+if (!tokenList.includes("random")) tokenList.push("random");
+tokenList.sort();
+
+// Demo template showcasing every supported form. All keys verified to exist.
+const STARTER = `{
+  "subject": "[character.fantasy]",
+  "art_style": [art.style],
+  "two_styles": [art.style, 2],
+  "artist_reference": [artist.all],
+  "color_palette": [color.palette],
+  "lighting": [photography.light],
+  "camera": "[photography.camera] with a [photography.lens]",
+  "mood": [feeling.all],
+  "tags": [[art.style], [art.style], [art.style]],
+  "scene": "A [art.style] scene of [character.fantasy], lit by [photography.light]",
+  "year": [time.year]
+}`;
+
+const Item = ({ entity }) => <div className="px-1">{`${entity}`}</div>;
+
+const JsonTemplateBuilder = () => {
+  const [template, setTemplate] = useState(STARTER);
+  const [preview, setPreview] = useState(null); // resolved object
+  const [error, setError] = useState(null); // { message, output? }
+  const [variations, setVariations] = useState([]);
+  const [count, setCount] = useState(8);
+  const [copied, setCopied] = useState("");
+  const textareaRef = useRef(null);
+
+  const apply = (data) => {
+    if (data.error) {
+      setError({ message: data.error, output: data.output });
+      setPreview(null);
+    } else {
+      setPreview(data.prompts[0]);
+      setError(null);
+    }
+  };
+
+  const fetchPreview = useCallback((tpl) => {
+    fetch("/api/generate-json", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ template: tpl, count: 1 }),
+    })
+      .then((r) => r.json())
+      .then(apply)
+      .catch((e) => setError({ message: String(e) }));
+  }, []);
+
+  const debouncedPreview = useRef(debounce((tpl) => fetchPreview(tpl), 400)).current;
+
+  useEffect(() => {
+    fetchPreview(STARTER);
+  }, [fetchPreview]);
+
+  const handleChange = (e) => {
+    const value = e.target.value;
+    setTemplate(value);
+    debouncedPreview(value);
+  };
+
+  const generate = () => {
+    fetch("/api/generate-json", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ template, count }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.error) {
+          setError({ message: data.error, output: data.output });
+        } else {
+          setVariations(data.prompts);
+          setError(null);
+        }
+      })
+      .catch((e) => setError({ message: String(e) }));
+  };
+
+  const copy = (obj, key) => {
+    navigator.clipboard.writeText(JSON.stringify(obj, null, 2));
+    setCopied(key);
+    setTimeout(() => setCopied(""), 1200);
+  };
+
+  return (
+    <div>
+      <div className="bg-gray-50 border-2 border-gray-200 p-4 mb-6 text-sm">
+        <p className="mb-1">
+          Write JSON and drop in <code>[category.list]</code> tokens (type{" "}
+          <code>[</code> for autocomplete). On generate, each token is filled
+          from prompt-lists:
+        </p>
+        <ul className="list-disc ml-5 space-y-0.5">
+          <li>
+            <code>[art.style]</code> — a bare token becomes a quoted string →{" "}
+            <code>&quot;art deco&quot;</code>
+          </li>
+          <li>
+            <code>[art.style, 2]</code> — pick N, comma-joined →{" "}
+            <code>&quot;art deco, bauhaus&quot;</code>
+          </li>
+          <li>
+            <code>&quot;a [art.style] by [artist.all]&quot;</code> — tokens
+            inside a string interpolate in place
+          </li>
+          <li>
+            <code>[[art.style], [art.style]]</code> — an array of independent
+            picks → <code>[&quot;art deco&quot;, &quot;bauhaus&quot;]</code>
+          </li>
+        </ul>
+        <Link className="underline inline-block mt-2" href="/explore">
+          Browse the available lists
+        </Link>
+      </div>
+
+      <label className="text-lg font-bold mb-2 block">Template</label>
+      <ReactTextareaAutocomplete
+        value={template}
+        onChange={handleChange}
+        className="w-full border-2 border-gray-600 p-4 font-mono text-sm"
+        rows={16}
+        spellCheck="false"
+        minChar={0}
+        loadingComponent={() => <span></span>}
+        innerRef={(ta) => {
+          textareaRef.current = ta;
+        }}
+        trigger={{
+          "[": {
+            dataProvider: (token) =>
+              token
+                ? tokenList.filter((l) =>
+                    l.toLowerCase().includes(token.toLowerCase())
+                  )
+                : tokenList,
+            component: Item,
+            output: (item) => {
+              const ta = textareaRef.current;
+              const selection = ta ? ta.selectionStart : 0;
+              const value = ta ? ta.value : "";
+              const nextChar = value[selection];
+              return {
+                text: nextChar === "]" ? `[${item}` : `[${item}]`,
+                caretPosition: "end",
+              };
+            },
+          },
+        }}
+      />
+
+      <div className="flex items-center gap-2 mt-4 flex-wrap">
+        <button type="button" className="button" onClick={() => fetchPreview(template)}>
+          🎲 Re-roll
+        </button>
+        <button
+          type="button"
+          className="button"
+          disabled={!preview}
+          onClick={() => copy(preview, "preview")}
+        >
+          {copied === "preview" ? "Copied!" : "Copy JSON"}
+        </button>
+        <span className="mx-1 text-gray-400">|</span>
+        <button type="button" className="button" onClick={generate}>
+          Generate
+        </button>
+        <input
+          type="number"
+          min="1"
+          max="100"
+          value={count}
+          onChange={(e) => setCount(parseInt(e.target.value, 10) || 1)}
+          className="border-2 border-gray-600 p-2 w-20"
+          aria-label="number of variations"
+        />
+        <span className="text-sm text-gray-600">variations</span>
+      </div>
+
+      {error && (
+        <div className="mt-6 border-2 border-red-400 bg-red-50 p-4">
+          <p className="font-bold text-red-700 mb-1">⚠ {error.message}</p>
+          {error.output && (
+            <pre className="text-xs overflow-x-auto whitespace-pre-wrap text-red-900">
+              {error.output}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {!error && preview && (
+        <div className="mt-6">
+          <label className="text-lg font-bold mb-2 block">Preview</label>
+          <pre className="border-2 border-gray-300 bg-gray-50 p-4 text-sm overflow-x-auto">
+            {JSON.stringify(preview, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      {variations.length > 0 && (
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-2">
+            <label className="text-lg font-bold">{variations.length} variations</label>
+            <button
+              type="button"
+              className="button"
+              onClick={() => copy(variations, "all")}
+            >
+              {copied === "all" ? "Copied!" : "Copy all (array)"}
+            </button>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {variations.map((v, i) => (
+              <div key={i} className="border-2 border-gray-300 relative">
+                <button
+                  type="button"
+                  className="absolute top-1 right-1 text-xs underline text-gray-500"
+                  onClick={() => copy(v, `v${i}`)}
+                >
+                  {copied === `v${i}` ? "Copied!" : "Copy"}
+                </button>
+                <pre className="p-3 text-xs overflow-x-auto">
+                  {JSON.stringify(v, null, 2)}
+                </pre>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default JsonTemplateBuilder;

--- a/pages/api/generate-json.js
+++ b/pages/api/generate-json.js
@@ -1,0 +1,134 @@
+import { callLists } from "./_all-lists";
+
+// Resolve a single token's inner text, e.g. "art.style" or "art.style, 2".
+// Mirrors the semantics of pages/api/generate.js: optional count (default 1,
+// capped at 50), "[random]" picks from a random list, unknown lists return null.
+const resolveToken = (inner) => {
+  const parts = inner.split(",");
+  const listName = parts[0].trim();
+  let count = parts.length >= 2 ? parseInt(parts[1], 10) : 1;
+  if (isNaN(count)) count = 1;
+  count = Math.min(Math.max(count, 1), 50);
+
+  if (listName === "random") {
+    const names = Object.keys(callLists);
+    const picks = [];
+    for (let i = 0; i < count; i++) {
+      const rnd = names[Math.floor(Math.random() * names.length)];
+      picks.push(callLists[rnd](1).join(", "));
+    }
+    return picks.join(", ");
+  }
+
+  if (!callLists[listName]) return null;
+  return callLists[listName](count).join(", ");
+};
+
+const jsonEscape = (str) =>
+  String(str)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+
+// A token bracket holds "category.list", "category.list, N", or "random[, N]".
+// Anything else (e.g. a real JSON array like ["a", "b"]) is left untouched.
+const TOKEN_RE = /^(?:[a-zA-Z][\w]*\.[\w]+|random)(?:\s*,\s*\d+)?$/;
+
+// Walk the template tracking JSON string state, replacing [tokens]:
+//   - inside a string -> interpolated in place (escaped)
+//   - bare (value position) -> a quoted JSON string of the resolved value
+// Returns resolved JSON text (still needs JSON.parse to validate).
+const resolveTemplate = (template) => {
+  let out = "";
+  let inString = false;
+
+  for (let i = 0; i < template.length; i++) {
+    const ch = template[i];
+
+    if (inString) {
+      if (ch === "\\") {
+        out += ch + (template[i + 1] ?? "");
+        i++;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+        out += ch;
+        continue;
+      }
+      if (ch === "[") {
+        const end = template.indexOf("]", i);
+        if (end !== -1) {
+          const inner = template.slice(i + 1, end).trim();
+          if (TOKEN_RE.test(inner)) {
+            const resolved = resolveToken(inner);
+            out += jsonEscape(resolved === null ? `[${inner}]` : resolved);
+            i = end;
+            continue;
+          }
+        }
+      }
+      out += ch;
+      continue;
+    }
+
+    // Outside a string.
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "[") {
+      const end = template.indexOf("]", i);
+      if (end !== -1) {
+        const inner = template.slice(i + 1, end).trim();
+        if (TOKEN_RE.test(inner)) {
+          const resolved = resolveToken(inner);
+          out += '"' + jsonEscape(resolved === null ? `[${inner}]` : resolved) + '"';
+          i = end;
+          continue;
+        }
+      }
+      // Not a token — a real JSON array. Emit "[" and keep scanning so any
+      // bare tokens nested inside become their own JSON strings.
+    }
+    out += ch;
+  }
+
+  return out;
+};
+
+export default function handler(req, res) {
+  const isPost = req.method === "POST";
+  if (!isPost && req.method !== "GET") {
+    res.setHeader("Allow", ["GET", "POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const template = isPost ? req.body.template : req.query.template;
+  let count = (isPost ? req.body.count : req.query.count) || 1;
+  count = Math.min(Math.max(parseInt(count, 10) || 1, 1), 100);
+
+  if (!template || !String(template).trim()) {
+    return res.status(400).json({ error: "No template provided" });
+  }
+
+  // Validate the structure once; resolved tokens vary but the JSON shape doesn't.
+  const sample = resolveTemplate(template);
+  try {
+    JSON.parse(sample);
+  } catch (e) {
+    return res.status(200).json({
+      error: `Template doesn't resolve to valid JSON: ${e.message}`,
+      output: sample,
+    });
+  }
+
+  const prompts = [];
+  for (let i = 0; i < count; i++) {
+    prompts.push(JSON.parse(resolveTemplate(template)));
+  }
+  return res.status(200).json({ prompts });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,6 +24,8 @@ export default function Home() {
           <h3 class="font-bold text-lg mb-2">How to write a prompt</h3>
           <p className="mb-2">Try using a ‘[’ character to open a drop-down menu of all available lists, like [animal.all].<br />When you generate prompts, an item is picked from each list, such as giraffe or lion for [animal.all].</p>
           <Link className="underline" href="/explore">Explore the available lists</Link>
+          <span className="mx-2 text-gray-400">·</span>
+          <Link className="underline" href="/json">Craft JSON prompt templates</Link>
         </div>
 
         <PromptForm />

--- a/pages/json.js
+++ b/pages/json.js
@@ -1,0 +1,32 @@
+import Head from "next/head";
+import Navbar from "../components/Navbar";
+import Meta from "../components/Meta";
+import JsonTemplateBuilder from "../components/JsonTemplateBuilder";
+
+const title = "JSON templates";
+
+export default function JsonTemplates() {
+  return (
+    <div>
+      <div className="container max-w-4xl mx-auto px-8 py-4 pb-10 bg-white border-black min-h-screen">
+        <Head>
+          <title>JSON prompt templates — Prompter</title>
+          <Meta />
+        </Head>
+
+        <Navbar />
+
+        <h1 className="calistoga md:text-7xl text-5xl text-black text-center mb-6 pt-10">
+          {title}
+        </h1>
+
+        <p className="mb-8 text-center max-w-2xl mx-auto">
+          Craft structured JSON prompts with <code>[category.list]</code> tokens,
+          then generate filled-in variations to drop straight into Explorer.
+        </p>
+
+        <JsonTemplateBuilder />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Proof-of-concept for crafting **JSON prompt templates** with `[category.list]` tokens (for use in Explorer). New page at **`/json`** (linked from the home page).

### Token syntax
| You write | You get |
|---|---|
| `[art.style]` | bare token → a quoted JSON string: `"art deco"` |
| `[art.style, 2]` | N picks, comma-joined: `"art deco, bauhaus"` |
| `"a [art.style] by [artist.all]"` | tokens inside a string interpolate in place |
| `[[art.style], [art.style]]` | array of independent picks: `["art deco", "bauhaus"]` |

Resolution runs **server-side** against `prompt-lists` (reusing the existing `callLists` map and mirroring `generate.js` token semantics, incl. `[random]`). A small string-state scanner distinguishes bare tokens (value position) from in-string tokens and from real JSON arrays, then `JSON.parse` validates the result and surfaces errors.

### UX (easy-to-use goals)
- `[` autocomplete over all list names (same component pattern as the main prompt box)
- Live preview, **🎲 Re-roll**, **Copy JSON**, and **Generate N variations** (each copyable, plus copy-all-as-array)
- A starter template + inline syntax help; invalid JSON shows a clear error

### Files (additive)
- `pages/api/generate-json.js` — resolver + API handler
- `components/JsonTemplateBuilder.js` — editor UI (isolated; touches no existing component)
- `pages/json.js` — page; one link added to `pages/index.js`

### Checks
- `npm run lint` — 0 errors (only the pre-existing PromptForm warning remains)
- `npm run build` — passes; `/json` + `/api/generate-json` build cleanly
- Smoke-tested the API at runtime (all token forms + the invalid-template error path)

This is a POC for review/feedback — happy to iterate on syntax (e.g. explicit array form, defaults, nested objects) or wire a 'send to Explorer' handoff.