### PR TITLE
Bump prompt-lists to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "flowbite": "^4.0.2",
         "lodash.debounce": "^4.0.8",
         "next": "^16.2.10",
-        "prompt-lists": "^0.4.2",
+        "prompt-lists": "^0.5.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1185,9 +1185,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1203,9 +1200,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1223,9 +1217,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,9 +1232,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1585,9 +1573,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1603,9 +1588,6 @@
       "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1623,9 +1605,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1641,9 +1620,6 @@
       "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4787,9 +4763,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -5041,9 +5017,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5063,9 +5036,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5087,9 +5057,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5109,9 +5076,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5751,12 +5715,12 @@
       }
     },
     "node_modules/prompt-lists": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/prompt-lists/-/prompt-lists-0.4.2.tgz",
-      "integrity": "sha512-kMYjvxI13KJ1McposNTV0H9LQYemGmMFxiFTCp16n9kEah8gNtj2XhW9N99Trh0U0swRjvDav/lRR298jDetjg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/prompt-lists/-/prompt-lists-0.5.0.tgz",
+      "integrity": "sha512-Z4sO0gwoZNfLxzlh3iEfHUl2AP+huxLBp7C3TSWVWHcjwjIU/5tYLJPTsK28em57NeSnTICH+ZvcF0cNcKpL3A==",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "lodash": "^4.17.21"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "flowbite": "^4.0.2",
     "lodash.debounce": "^4.0.8",
     "next": "^16.2.10",
-    "prompt-lists": "^0.4.2",
+    "prompt-lists": "^0.5.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },


### PR DESCRIPTION
Bumps the prompt-lists dependency from ^0.4.2 to ^0.5.0 (v0.5.0 released today), per fofr's request. package.json + lockfile updated. Public repo so opened as a PR rather than a direct push.