### PR TITLE
security: add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule: { interval: weekly }
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       npm-minor-patch:
@@ -10,3 +12,5 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule: { interval: weekly }
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Fleet weekly security sweep — public repo, via PR for approval. Adds cooldown.default-days 7 to the existing npm + github-actions Dependabot blocks (additive; .npmrc min-release-age already present).

Co-authored-by: mac-claude <260684416+fofr-foffee@users.noreply.github.com>